### PR TITLE
Fix typo from 'vsxIcon' to 'VsxIcon' of the samplecode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Global registration:
 
 ```jsx
 // main.js
-import { vsxIcon, Wallet }  from 'vue-iconsax'
+import { VsxIcon, Wallet }  from 'vue-iconsax'
 const app = createApp(App)
 // Dynamic usage of icons - Use PascalCase for iconName prop
-app.component('vsxIcon', vsxIcon)
+app.component('VsxIcon', VsxIcon)
 // Static usage of icons
 app.component('Wallet', Wallet)
 app.mount('#app')
@@ -51,7 +51,7 @@ app.mount('#app')
 // App.vue
 <template>
   // Dynamic imports - Use PascalCase for iconName prop
-  <vsx-icon :iconName="iconName" color="blue" size="50" type="linear" />
+  <Vsx-icon :iconName="iconName" color="blue" size="50" type="linear" />
 
   // Static imports
   <Wallet color="blue" size="50" type="linear" />
@@ -69,17 +69,17 @@ Local registration:
 ```jsx
 <template>
   // Dynamic imports - Use PascalCase for iconName prop
-  <vsx-icon :iconName="iconName" color="blue" size="50" type="linear" />
+  <Vsx-icon :iconName="iconName" color="blue" size="50" type="linear" />
 
   // Static imports
   <Wallet color="blue" size="50" type="linear" />
 </template>
 
 <script>
-import { vsxIcon, Wallet } from "vue-iconsax";
+import { VsxIcon, Wallet } from "vue-iconsax";
 export default {
   components: {
-    vsxIcon,
+    VsxIcon,
     Wallet
   },
   props:['iconName']
@@ -94,7 +94,7 @@ export default {
 | `color`   | `string`                                            | `currentColor` | css color              |
 | `size`    | `number` `string`                                   | 24px           | size="24" or :size="24" |
 | `type` | `Linear` `Outline` `TwoTone` `Bulk` `Broken` `Bold` | `Linear`       | icons styles           |
-| `iconName` | string|              | iconName is only required with vsx-icon tag (Dynamic icon imports)
+| `iconName` | string|              | iconName is only required with Vsx-icon tag (Dynamic icon imports)
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Global registration:
 import { VsxIcon, Wallet }  from 'vue-iconsax'
 const app = createApp(App)
 // Dynamic usage of icons - Use PascalCase for iconName prop
-app.component('VsxIcon', VsxIcon)
+app.component('vsxIcon', VsxIcon)
 // Static usage of icons
 app.component('Wallet', Wallet)
 app.mount('#app')
@@ -51,7 +51,7 @@ app.mount('#app')
 // App.vue
 <template>
   // Dynamic imports - Use PascalCase for iconName prop
-  <Vsx-icon :iconName="iconName" color="blue" size="50" type="linear" />
+  <vsx-icon :iconName="iconName" color="blue" size="50" type="linear" />
 
   // Static imports
   <Wallet color="blue" size="50" type="linear" />
@@ -69,7 +69,7 @@ Local registration:
 ```jsx
 <template>
   // Dynamic imports - Use PascalCase for iconName prop
-  <Vsx-icon :iconName="iconName" color="blue" size="50" type="linear" />
+  <vsx-icon :iconName="iconName" color="blue" size="50" type="linear" />
 
   // Static imports
   <Wallet color="blue" size="50" type="linear" />
@@ -94,7 +94,7 @@ export default {
 | `color`   | `string`                                            | `currentColor` | css color              |
 | `size`    | `number` `string`                                   | 24px           | size="24" or :size="24" |
 | `type` | `Linear` `Outline` `TwoTone` `Bulk` `Broken` `Bold` | `Linear`       | icons styles           |
-| `iconName` | string|              | iconName is only required with Vsx-icon tag (Dynamic icon imports)
+| `iconName` | string|              | iconName is only required with vsx-icon tag (Dynamic icon imports)
 
 ## Contact
 


### PR DESCRIPTION
Hi Emad !

When I think I want to use icon-sax with vue, I found this repository.
This repository is so good !
Install to my project, implement like sample code, but I just can't run it correctly.
I read the README.md and index.ts, I found some typos

```
import { vsxIcon, Wallet }  from 'vue-iconsax'
...
app.component('vsxIcon', vsxIcon)
...
```

This is how it should be

```
import { VsxIcon, Wallet }  from 'vue-iconsax'
...
app.component('VsxIcon', vsxIcon)
...
```

I would be happy if you accept this pullrequest, thankyou.