### PR TITLE
Fix - Error when running vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "main": "./dist/index.js",
   "name": "vue-iconsax",
   "description": "Iconsax icon pack for Vue",
   "author": "Emad Moghimi <jaxtheprime@gmail.com>",


### PR DESCRIPTION
This is to resolve error when running vitest "Failed to resolve entry for package "vue-iconsax". The package may have incorrect main/module/exports specified in its package.json"

This solution is from https://github.com/vitest-dev/vitest/issues/2922#issuecomment-1446937792